### PR TITLE
Separate Connection and Channel. Introduce ConnectionConfig

### DIFF
--- a/src/main/scala/nl/vroste/zio/amqp/connection/Connection.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/connection/Connection.scala
@@ -1,0 +1,36 @@
+package nl.vroste.zio.amqp.connection
+
+import com.rabbitmq.client.{ Connection => RConnection, ConnectionFactory }
+import zio.ZIO.attemptBlocking
+import zio.{ RIO, Task, UIO, ZManaged }
+
+import nl.vroste.zio.amqp.channel.Channel
+
+import java.net.URI
+
+final class Connection private[amqp] (rconnection: RConnection) {
+  def createChannel: ZManaged[Any, Throwable, Channel] = Channel.make(rconnection)
+}
+
+object Connection {
+
+  def connect(uri: URI): ZManaged[Any, Throwable, Connection] = {
+    val factory = new ConnectionFactory()
+    factory.setUri(uri)
+    make(factory)
+  }
+
+  def connect(factory: ConnectionFactory): ZManaged[Any, Throwable, Connection] =
+    make(factory)
+
+  private[amqp] def make(factory: ConnectionFactory): ZManaged[Any, Throwable, Connection] = for {
+    rconn <- ZManaged.acquireReleaseWith(acquire(factory))(release)
+  } yield new Connection(rconn)
+
+  private def acquire(factory: ConnectionFactory): RIO[Any, RConnection] =
+    attemptBlocking(factory.newConnection())
+
+  private def release: RConnection => UIO[Unit] =
+    rconn => Task(rconn.close()).orDie
+
+}

--- a/src/main/scala/nl/vroste/zio/amqp/connection/config/ConnectionConfig.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/connection/config/ConnectionConfig.scala
@@ -1,0 +1,79 @@
+package nl.vroste.zio.amqp.connection.config
+
+import com.rabbitmq.client.ConnectionFactory
+
+import nl.vroste.zio.amqp.connection.config.ConnectionConfig.ConnectionSetting
+
+import java.net.URI
+
+final case class ConnectionConfig(
+  settings: List[ConnectionSetting] = Nil
+) {
+  private def withSetting(setting: ConnectionSetting): ConnectionConfig =
+    copy(settings = setting +: settings)
+
+  def withHost(host: String): ConnectionConfig =
+    withSetting(ConnectionSetting.Host(host))
+
+  def withPort(port: Int): ConnectionConfig =
+    withSetting(ConnectionSetting.Port(port))
+
+  def withUsername(username: String): ConnectionConfig =
+    withSetting(ConnectionSetting.Username(username))
+
+  def withPassword(password: String): ConnectionConfig =
+    withSetting(ConnectionSetting.Password(password))
+
+  def withUri(uri: String): ConnectionConfig =
+    withSetting(ConnectionSetting.UriRaw(uri))
+
+  def withUri(uri: URI): ConnectionConfig =
+    withSetting(ConnectionSetting.Uri(uri))
+}
+
+object ConnectionConfig {
+
+  def uri(uri: String): ConnectionConfig =
+    ConnectionConfig().withUri(uri)
+
+  def uri(uri: URI): ConnectionConfig =
+    ConnectionConfig().withUri(uri)
+
+  def hostPort(host: String, port: Int): ConnectionConfig =
+    ConnectionConfig().withHost(host).withPort(port)
+
+  sealed trait ConnectionSetting extends Product with Serializable {
+    def apply(factory: ConnectionFactory): ConnectionFactory = {
+      modification(factory)
+      factory
+    }
+
+    def modification: ConnectionFactory => Unit
+  }
+
+  object ConnectionSetting {
+    final case class Host(host: String) extends ConnectionSetting {
+      override val modification = _.setHost(host)
+    }
+
+    final case class Port(port: Int) extends ConnectionSetting {
+      override val modification = _.setPort(port)
+    }
+
+    final case class Username(username: String) extends ConnectionSetting {
+      override val modification = _.setUsername(username)
+    }
+
+    final case class Password(password: String) extends ConnectionSetting {
+      override val modification = _.setPassword(password)
+    }
+
+    final case class Uri(uri: URI) extends ConnectionSetting {
+      override val modification = _.setUri(uri)
+    }
+
+    final case class UriRaw(uri: String) extends ConnectionSetting {
+      override val modification = _.setUri(uri)
+    }
+  }
+}

--- a/src/main/scala/nl/vroste/zio/amqp/model/package.scala
+++ b/src/main/scala/nl/vroste/zio/amqp/model/package.scala
@@ -11,7 +11,9 @@ package object model {
   object ExchangeName extends Newtype[String]
   type ExchangeName = ExchangeName.Type
 
-  object RoutingKey extends Newtype[String]
+  object RoutingKey extends Newtype[String] {
+    lazy val default: RoutingKey = RoutingKey("")
+  }
   type RoutingKey = RoutingKey.Type
 
   object ConsumerTag extends Newtype[String]

--- a/src/test/scala/nl/vroste/zio/amqp/AmqpSpec.scala
+++ b/src/test/scala/nl/vroste/zio/amqp/AmqpSpec.scala
@@ -1,18 +1,21 @@
 package nl.vroste.zio.amqp
 import com.rabbitmq.client.ConnectionFactory
-import nl.vroste.zio.amqp.model._
 import zio.test.Assertion.equalTo
 import zio.test.TestAspect.timeout
 import zio.test._
 import zio.{ durationInt, Clock, Duration, ZIO }
+
+import nl.vroste.zio.amqp.connection.Connection
+import nl.vroste.zio.amqp.model._
 
 import java.net.URI
 import java.nio.charset.StandardCharsets
 import java.util.UUID
 import java.util.concurrent.TimeUnit
 
-object AmqpClientSpec extends DefaultRunnableSpec {
-  val fallback      = "amqp://guest:guest@0.0.0.0:5672"
+object AmqpSpec extends DefaultRunnableSpec {
+  val fallback = "amqp://guest:guest@0.0.0.0:5672"
+
   override def spec =
     suite("AmqpClientSpec")(
       test("Amqp.consume delivers messages") {
@@ -27,9 +30,10 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         println(uri)
         factory.setUri(uri)
 
-        (Amqp
+        Connection
           .connect(factory)
-          .tapZIO(_ => ZIO(println("Connected!"))) flatMap Amqp.createChannel)
+          .tapZIO(_ => ZIO(println("Connected!")))
+          .flatMap(_.createChannel)
           .tapZIO(_ => ZIO(println("Created channel!")))
           .use { channel =>
             for {
@@ -69,9 +73,10 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         println(uri)
         factory.setUri(uri)
 
-        (Amqp
+        Connection
           .connect(factory)
-          .tapZIO(_ => ZIO(println("Connected!"))) flatMap Amqp.createChannel)
+          .tapZIO(_ => ZIO(println("Connected!")))
+          .flatMap(_.createChannel)
           .tapZIO(_ => ZIO(println("Created channel!")))
           .use { channel =>
             for {
@@ -110,9 +115,9 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse(fallback))
         factory.setUri(uri)
 
-        Amqp
+        Connection
           .connect(factory)
-          .flatMap(Amqp.createChannel)
+          .flatMap(_.createChannel)
           .use { channel =>
             for {
               _ <- channel.queueDeclare(queueName)
@@ -128,9 +133,9 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse(fallback))
         factory.setUri(uri)
 
-        (Amqp
+        (Connection
           .connect(factory)
-          .flatMap(Amqp.createChannel)
+          .flatMap(_.createChannel)
           .use { channel =>
             for {
               _      <- channel.queueDeclare(queueName)
@@ -153,9 +158,9 @@ object AmqpClientSpec extends DefaultRunnableSpec {
         val uri            = URI.create(Option(System.getenv("AMQP_SERVER_URI")).getOrElse(fallback))
         factory.setUri(uri)
 
-        (Amqp
+        (Connection
           .connect(factory)
-          .flatMap(Amqp.createChannel)
+          .flatMap(_.createChannel)
           .use { channel =>
             for {
               _      <- channel.queueDeclare(queueName)


### PR DESCRIPTION
I don't like how configuration is implemented in fs2-rabbit and akka-alpakka. So I suggest this approach. It allows user to work with configuration just like with connection factory (e.g. set parameters with uri and then overwrite them partially) in functional way. But it makes getting parameters back from config impossible.